### PR TITLE
Fix links and unify styling

### DIFF
--- a/public/08_resilience_and_sustainability_1.html
+++ b/public/08_resilience_and_sustainability_1.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
   <!-- Google Icons + Custom Styles -->
+  <link href="https://fonts.cdnfonts.com/css/eagle-4" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined">
   <link rel="stylesheet" href="css/styles.css" />
   <link rel="stylesheet" href="css/custom.css" />

--- a/public/09_help_dark_blue.html
+++ b/public/09_help_dark_blue.html
@@ -6,7 +6,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Instructions</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/eagle-4">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined">
+  <link rel="stylesheet" href="css/styles.css" />
   <style>
     body {
       background-color: #0c2357;

--- a/public/17_interconnected_water_systems_1.html
+++ b/public/17_interconnected_water_systems_1.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
   <!-- Google Icons + Custom Styles -->
+  <link href="https://fonts.cdnfonts.com/css/eagle-4" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined">
   <link rel="stylesheet" href="css/styles.css" />
   <link rel="stylesheet" href="css/custom.css" />
@@ -172,7 +173,7 @@
           <button id="back-btn-3" class="btn btn-secondary btn-lg nav-btn" aria-label="Back">
             &#11013;
           </button>
-          <a href="/key_concepts_of_one_water.html"
+          <a href="key_concepts_of_one_water.html"
              class="btn btn-outline-light btn-lg nav-btn"
              aria-label="Back to Key Concepts">
             <span class="material-symbols-outlined align-middle">home</span>

--- a/public/26_water_equity.html
+++ b/public/26_water_equity.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
   <!-- Google Icons + Custom Styles -->
+  <link href="https://fonts.cdnfonts.com/css/eagle-4" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined">
   <link rel="stylesheet" href="css/styles.css" />
   <link rel="stylesheet" href="css/custom.css" />
@@ -172,7 +173,7 @@
     <!-- Nav buttons -->
     <div class="d-flex justify-content-between mt-4">
       <button id="back-btn-2" class="btn btn-secondary btn-lg nav-btn" aria-label="Back">&#11013;</button>
-      <a href="/key_concepts_of_one_water.html"
+      <a href="key_concepts_of_one_water.html"
          class="btn btn-outline-light btn-lg nav-btn"
          aria-label="Back to Key Concepts">
         <span class="material-symbols-outlined align-middle">home</span>

--- a/public/__one_water_many_cities.html
+++ b/public/__one_water_many_cities.html
@@ -9,6 +9,7 @@
   <!-- Bootstrap & Fonts -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/eagle-4">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined">
   <link rel="stylesheet" href="css/styles.css" />
   <link rel="stylesheet" href="css/custom.css" />

--- a/public/base template.html
+++ b/public/base template.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
   <!-- Google Icons + Custom Styles -->
+  <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/eagle-4">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined">
   <link rel="stylesheet" href="css/styles.css" />
   <link rel="stylesheet" href="css/custom.css" />
@@ -172,7 +173,7 @@
           <button id="back-btn-3" class="btn btn-secondary btn-lg nav-btn" aria-label="Back">
             &#11013;
           </button>
-          <a href="/key_concepts_of_one_water.html"
+          <a href="key_concepts_of_one_water.html"
              class="btn btn-outline-light btn-lg nav-btn"
              aria-label="Back to Key Concepts">
             <span class="material-symbols-outlined align-middle">home</span>

--- a/public/glossary.html
+++ b/public/glossary.html
@@ -6,7 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/eagle-4">
+  <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
   <div class="container">

--- a/public/help.html
+++ b/public/help.html
@@ -6,7 +6,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Instructions</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/eagle-4">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined">
+  <link rel="stylesheet" href="css/styles.css" />
   <style>
     body {
       background-color: #e8f0fa;

--- a/public/key_concepts_of_one_water.html
+++ b/public/key_concepts_of_one_water.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
   <!-- Custom CSS (optional) -->
+  <link href="https://fonts.cdnfonts.com/css/eagle-4" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined">
   <link rel="stylesheet" href="css/styles.css" />
   <link rel="stylesheet" href="css/custom.css" />

--- a/public/one_water_houston.html
+++ b/public/one_water_houston.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
   <!-- Custom CSS -->
+  <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/eagle-4">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined">
   <link rel="stylesheet" href="css/styles.css" />
   <link rel="stylesheet" href="css/custom.css" />

--- a/public/one_water_many_cities.html
+++ b/public/one_water_many_cities.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
   <!-- Google Icons + Custom Styles -->
+  <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/eagle-4">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined">
   <link rel="stylesheet" href="css/styles.css" />
   <link rel="stylesheet" href="css/custom.css" />
@@ -102,7 +103,7 @@
         <!-- Back + Home nav -->
         <div class="d-flex justify-content-between mt-4">
           <button id="back-btn-2" class="btn btn-secondary btn-lg nav-btn" aria-label="Back">&#11013;</button>
-          <a href="/key_concepts_of_one_water.html"
+          <a href="key_concepts_of_one_water.html"
              class="btn btn-outline-light btn-lg nav-btn"
              aria-label="Back to Key Concepts">
             <span class="material-symbols-outlined align-middle">home</span>
@@ -152,7 +153,7 @@
 
         <div class="d-flex justify-content-between mt-4">
           <button id="map-return-3" class="btn btn-secondary btn-lg nav-btn" aria-label="Back to map">&#11013;</button>
-          <a href="/key_concepts_of_one_water.html"
+          <a href="key_concepts_of_one_water.html"
              class="btn btn-outline-light btn-lg nav-btn"
              aria-label="Back to Key Concepts">
             <span class="material-symbols-outlined align-middle">home</span>
@@ -198,7 +199,7 @@
 
         <div class="d-flex justify-content-between mt-4">
           <button id="map-return-4" class="btn btn-secondary btn-lg nav-btn" aria-label="Back to map">&#11013;</button>
-          <a href="/key_concepts_of_one_water.html"
+          <a href="key_concepts_of_one_water.html"
              class="btn btn-outline-light btn-lg nav-btn"
              aria-label="Back to Key Concepts">
             <span class="material-symbols-outlined align-middle">home</span>


### PR DESCRIPTION
## Summary
- rename help page and fix references
- add Eagle font and stylesheet across pages
- remove root slashes from navigation links
- correct glossary stylesheet path

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68828484ac6483238ac2f5989a183f7e